### PR TITLE
Fix event loop usage

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -2,19 +2,17 @@ from telegram.ext import ApplicationBuilder
 from bot.handlers import register_handlers
 from bot.config import TOKEN
 from bot.utils import load_wins
-import asyncio
 
-async def main():
+def main():
+    """Start the bot using Application.run_polling."""
     application = ApplicationBuilder().token(TOKEN).build()
-    await register_handlers(application)
+    register_handlers(application)
     load_wins()
     print("✅ Бот запущен и слушает команды...")
-    await application.run_polling()
+    application.run_polling()
 
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop()
-    loop.create_task(main())
-    loop.run_forever()
+    main()
 
 
 

--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -134,7 +134,7 @@ async def button_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         query.edit_message_text("Неизвестное действие.")
 
 
-async def register_handlers(application):
+def register_handlers(application):
     application.add_handler(CommandHandler("start", start))
     application.add_handler(CommandHandler("motivate", motivate))
     application.add_handler(CommandHandler("creator", creator))

--- a/bot/jfood.py
+++ b/bot/jfood.py
@@ -8,7 +8,7 @@ from telegram.ext import ContextTypes
 from .config import JFOOD_FILE
 
 
-async def load_jfood():
+def load_jfood():
     if os.path.exists(JFOOD_FILE):
         with open(JFOOD_FILE, "r", encoding="utf-8") as f:
             return json.load(f)
@@ -19,7 +19,7 @@ async def load_jfood():
         }
 
 
-async def save_jfood(data):
+def save_jfood(data):
     with open(JFOOD_FILE, "w", encoding="utf-8") as f:
         json.dump(data, f, ensure_ascii=False, indent=2)
 


### PR DESCRIPTION
## Summary
- remove manual `asyncio` loop in `bot.py`
- register handlers in a regular function
- adjust `jfood` helper functions to be synchronous

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python bot.py` *(fails: httpx.ProxyError 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686403762044832384cb300ce2fdeb46